### PR TITLE
Feature/improve nil

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -105,7 +105,7 @@ func TestDecodeNil(t *testing.T) {
 
 		var v interface{}
 		err := dec.Decode(&v)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, nil, v)
 	})
 
@@ -115,17 +115,46 @@ func TestDecodeNil(t *testing.T) {
 
 		var v map[int]int
 		err := dec.Decode(&v)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, map[int]int(nil), v)
 	})
 
-	t.Run("assignable to int (set to not reference value will fail)", func(t *testing.T) {
+	t.Run("assignable to slice (interface)", func(t *testing.T) {
+		r := bytes.NewReader(bin)
+		dec := NewDecoder(r)
+
+		var v []interface{}
+		err := dec.Decode(&v)
+		require.NoError(t, err)
+		require.Equal(t, []interface{}(nil), v)
+	})
+
+	t.Run("assignable to slice (non-nil primitive)", func(t *testing.T) {
+		r := bytes.NewReader(bin)
+		dec := NewDecoder(r)
+
+		var v []int
+		err := dec.Decode(&v)
+		require.NoError(t, err)
+		require.Equal(t, []int(nil), v)
+	})
+
+	t.Run("NOT assignable to array (despite the length)", func(t *testing.T) {
+		r := bytes.NewReader(bin)
+		dec := NewDecoder(r)
+
+		var v [42]interface{}
+		err := dec.Decode(&v)
+		require.Error(t, err)
+	})
+
+	t.Run("NOT assignable to int (set to not reference value will fail)", func(t *testing.T) {
 		r := bytes.NewReader(bin)
 		dec := NewDecoder(r)
 
 		var v int
 		err := dec.Decode(&v)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -268,7 +297,7 @@ func TestDecodeStrictArraySame(t *testing.T) {
 
 		var v []string
 		err := dec.Decode(&v)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, []string{"str", "str"}, v)
 	})
 
@@ -278,7 +307,7 @@ func TestDecodeStrictArraySame(t *testing.T) {
 
 		var v [2]string
 		err := dec.Decode(&v)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, [2]string{"str", "str"}, v)
 	})
 
@@ -288,7 +317,7 @@ func TestDecodeStrictArraySame(t *testing.T) {
 
 		var v [10]string
 		err := dec.Decode(&v)
-		require.NotNil(t, err) // should support an array which has length that more than of equals to length of an encoded strict array?
+		require.Error(t, err) // should support an array which has length that more than of equals to length of an encoded strict array?
 	})
 }
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -342,3 +342,19 @@ func TestDecodeStrictArrayHetero(t *testing.T) {
 		require.NotNil(t, err)
 	})
 }
+
+func TestDecodeUnknownMarker(t *testing.T) {
+	bin := []byte{
+		// Unknown Marker
+		0xff,
+	}
+
+	t.Run("Cannot decode", func(t *testing.T) {
+		r := bytes.NewReader(bin)
+		dec := NewDecoder(r)
+
+		var v interface{}
+		err := dec.Decode(&v)
+		require.Error(t, err)
+	})
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -26,10 +26,14 @@ func TestDecodeCommon(t *testing.T) {
 
 			var v interface{}
 			err := dec.Decode(&v)
-			require.Nil(t, err)
-			require.Equal(t, tc.Value, v)
+			require.NoError(t, err)
+			if tc.AssumeNil {
+				require.Nil(t, v)
+			} else {
+				require.Equal(t, tc.Value, v)
+			}
 
-			require.Equal(t, 0, r.Len())
+			require.Equal(t, 0, r.Len()) // Assure that all bytes are consumed
 		})
 	}
 }

--- a/encoder.go
+++ b/encoder.go
@@ -60,9 +60,15 @@ func (enc *Encoder) encode(rv reflect.Value) error {
 		return enc.encodeString(rv)
 
 	case reflect.Map:
+		if rv.IsNil() {
+			return enc.encodeNull()
+		}
 		return enc.encodeMap(rv)
 
 	case reflect.Array, reflect.Slice:
+		if rv.IsNil() {
+			return enc.encodeNull()
+		}
 		return enc.encodeStrictArray(rv)
 
 	case reflect.Interface:

--- a/encoder.go
+++ b/encoder.go
@@ -291,7 +291,7 @@ func (enc *Encoder) encodeStrictArray(rv reflect.Value) error {
 
 func (enc *Encoder) encodeDate(rv reflect.Value) error {
 	t := rv.Interface().(time.Time)
-	t = t.In(time.UTC) // Time zone is not supported yet, thus force convert to UTC. TODO: fix
+	t = t.In(time.UTC) // Time zone is not supported yet, thus force convert to UTC. TODO: support time zone
 
 	if t.UnixNano()%int64(time.Millisecond) != 0 {
 		return fmt.Errorf("date time of nano sec is not supported: Expected = 0, Actual = %d", t.UnixNano()%int64(time.Millisecond))

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -41,3 +41,12 @@ func TestEncodeObjectEnd(t *testing.T) {
 	err := enc.Encode(ObjectEnd)
 	require.Nil(t, err)
 }
+
+func TestEncodeUnsupportedTypes(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{})
+	enc := NewEncoder(buf)
+
+	ch := make(chan int) // cannot encode
+	err := enc.Encode(ch)
+	require.Error(t, err)
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestEncodeCommon(t *testing.T) {
-	allTestCases := append(append([]testCase{}, testCases...), onlyEncodingTestCases...)
+	allTestCases := append(append([]testCase{}, testCases...), ptrNestedNumberTest, objectTest)
 
 	for _, tc := range allTestCases {
 		tc := tc // capture

--- a/export_test.go
+++ b/export_test.go
@@ -71,8 +71,17 @@ var testCases = []testCase{
 		},
 	},
 	{
-		Name:  "Nil Object",
+		Name:  "Nil Map",
 		Value: (map[string]interface{})(nil),
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
+	},
+	{
+		Name:  "Nil Object",
+		Value: (interface{})(nil),
 		Binary: []byte{
 			// null Marker
 			0x05,

--- a/export_test.go
+++ b/export_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 type testCase struct {
-	Name   string
-	Value  interface{}
-	Binary []byte
+	Name      string
+	Value     interface{}
+	Binary    []byte
+	AssumeNil bool
 }
 
 var number20ForAddr = 20
@@ -136,6 +137,42 @@ var testCases = []testCase{
 			// Time zone
 			0x00, 0x00,
 		},
+	},
+	{
+		Name:  "Nil",
+		Value: nil,
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
+	},
+	{
+		Name:  "Nil Object",
+		Value: (map[string]interface{})(nil),
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
+	},
+	{
+		Name:  "Nil Slice",
+		Value: ([]interface{})(nil),
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
+	},
+	{
+		Name:  "Nil ECMAArray",
+		Value: (ECMAArray)(nil),
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
 	},
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -18,11 +18,8 @@ type testCase struct {
 	AssumeNil bool
 }
 
-var number20ForAddr = 20
-
-type sampleObject struct {
-	A string `amf0:"a"`
-	B int    `amf0:"b"`
+func intPtr(v int) *int {
+	return &v
 }
 
 var testCases = []testCase{
@@ -72,6 +69,33 @@ var testCases = []testCase{
 			// Null Marker
 			0x05,
 		},
+	},
+	{
+		Name:  "Nil Object",
+		Value: (map[string]interface{})(nil),
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
+	},
+	{
+		Name:  "Nil Slice",
+		Value: ([]interface{})(nil),
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
+	},
+	{
+		Name:  "Nil ECMAArray",
+		Value: (ECMAArray)(nil),
+		Binary: []byte{
+			// null Marker
+			0x05,
+		},
+		AssumeNil: true,
 	},
 	{
 		Name: "ECMA Array",
@@ -139,57 +163,55 @@ var testCases = []testCase{
 		},
 	},
 	{
-		Name:  "Nil",
-		Value: nil,
-		Binary: []byte{
-			// null Marker
-			0x05,
+		Name: "Complex Nested",
+		Value: map[string]interface{}{
+			"1": "abc",
+			"2": map[string]interface{}{
+				"a": "str",
+				"b": float64(42),
+			},
 		},
-		AssumeNil: true,
-	},
-	{
-		Name:  "Nil Object",
-		Value: (map[string]interface{})(nil),
 		Binary: []byte{
-			// null Marker
-			0x05,
+			0x03,       // Object Marker
+			0x00, 0x01, // - Length(1: u16) BigEndian
+			0x31,       //   Key(1: []byte)
+			0x02,       //   - String Marker
+			0x00, 0x03, //     Length(3: u16) BigEndian
+			0x61, 0x62, 0x63, // Value(abc: []byte)
+			0x00, 0x01, // - Length(1: u16) BigEndian
+			0x32,       //   Key(2: []byte)
+			0x03,       //   - Object Marker
+			0x00, 0x01, //     Length(1: u16) BigEndian
+			0x61,       //       Key(a: []byte)
+			0x02,       //       - String Marker
+			0x00, 0x03, //         Length(3: u16) BigEndian
+			0x73, 0x74, 0x72, // Value(str: []byte)
+			0x00, 0x01, //     Length(1: u16) BigEndian
+			0x62,                                           //       Key(b: []byte)
+			0x00,                                           //       - Number Marker
+			0x40, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Value(42: double) BigEndian
+			0x00, 0x00, // - Length(0: u16) BigEndian
+			0x09,       //   Key(empty)
+			0x00, 0x00, // - Length(0: u16) BigEndian
+			0x09, //   Key(empty)
 		},
-		AssumeNil: true,
 	},
-	{
-		Name:  "Nil Slice",
-		Value: ([]interface{})(nil),
-		Binary: []byte{
-			// null Marker
-			0x05,
-		},
-		AssumeNil: true,
-	},
-	{
-		Name:  "Nil ECMAArray",
-		Value: (ECMAArray)(nil),
-		Binary: []byte{
-			// null Marker
-			0x05,
-		},
-		AssumeNil: true,
-	},
-}
-
-var onlyEncodingTestCases = []testCase{
-	ptrNestedNumberTest,
-	objectTest,
 }
 
 var ptrNestedNumberTest = testCase{
 	Name:  "Number(Int ptr)",
-	Value: &number20ForAddr,
+	Value: intPtr(20),
 	Binary: []byte{
 		// Number Marker
 		0x00,
 		// Value(20: double) BigEndian
 		0x40, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	},
+}
+
+type sampleObject struct {
+	A string `amf0:"a"`
+	B int    `amf0:"b"`
 }
 
 var objectTest = testCase{


### PR DESCRIPTION
Now empty objects, maps, arrays and slices are encoded into Nil values in amf0.